### PR TITLE
Added Perl. 

### DIFF
--- a/norm_common.functions
+++ b/norm_common.functions
@@ -30,11 +30,11 @@ pushd_src() {
 }
 
 do_configure() {
-    ./configure --prefix="$PREFIX" "$@" 2>&1 | $CONFIGURE_FILTER | tee $COMPILEDIR/$TARNAME-configure.log || exit 1
+    ./configure --prefix="$PREFIX" "$@" 2>&1 | $CONFIGURE_FILTER | tee $COMPILEDIR/$TARNAME-configure.log || ./configure.gnu --prefix="$PREFIX" "$@" 2>&1 | $CONFIGURE_FILTER | tee $COMPILEDIR/$TARNAME-configure.log || exit 1
 }
 
 do_configure_outside() {
-    "$SRCDIR"/configure --prefix="$PREFIX" "$@" 2>&1 | tee $COMPILEDIR/$TARNAME-configure.log || exit 1
+    "$SRCDIR"/configure --prefix="$PREFIX" "$@" 2>&1 | tee $COMPILEDIR/$TARNAME-configure.log || "$SRCDIR"/configure.gnu --prefix="$PREFIX" "$@" 2>&1 | tee $COMPILEDIR/$TARNAME-configure.log || exit 1
 }
 
 do_make() {

--- a/norm_common.functions
+++ b/norm_common.functions
@@ -30,11 +30,11 @@ pushd_src() {
 }
 
 do_configure() {
-    ./configure --prefix="$PREFIX" "$@" 2>&1 | $CONFIGURE_FILTER | tee $COMPILEDIR/$TARNAME-configure.log || ./configure.gnu --prefix="$PREFIX" "$@" 2>&1 | $CONFIGURE_FILTER | tee $COMPILEDIR/$TARNAME-configure.log || exit 1
+    ./configure --prefix="$PREFIX" "$@" 2>&1 | $CONFIGURE_FILTER | tee $COMPILEDIR/$TARNAME-configure.log || exit 1
 }
 
 do_configure_outside() {
-    "$SRCDIR"/configure --prefix="$PREFIX" "$@" 2>&1 | tee $COMPILEDIR/$TARNAME-configure.log || "$SRCDIR"/configure.gnu --prefix="$PREFIX" "$@" 2>&1 | tee $COMPILEDIR/$TARNAME-configure.log || exit 1
+    "$SRCDIR"/configure --prefix="$PREFIX" "$@" 2>&1 | tee $COMPILEDIR/$TARNAME-configure.log || exit 1
 }
 
 do_make() {

--- a/packages/perl
+++ b/packages/perl
@@ -4,7 +4,7 @@ fetch_source http://www.cpan.org/src/5.0/perl-5.20.0.tar.gz 52087047fd35e1020387
 
 do_unpack
 pushd_src
-./configure.gnu
+./Configure -de -Dprefix=$PREFIX
 do_make
 do_install
 popd

--- a/packages/perl
+++ b/packages/perl
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+fetch_source http://www.cpan.org/src/5.0/perl-5.20.0.tar.gz 52087047fd35e1020387f7c492f594a397be4e12
+
+do_unpack_compile

--- a/packages/perl
+++ b/packages/perl
@@ -2,4 +2,9 @@
 
 fetch_source http://www.cpan.org/src/5.0/perl-5.20.0.tar.gz 52087047fd35e1020387f7c492f594a397be4e12
 
-do_unpack_compile
+do_unpack
+pushd_src
+./configure.gnu
+do_make
+do_install
+popd


### PR DESCRIPTION
Perl is a bit different, instead of one configure script it has two. One is named configure.gnu and the other configure.com, modified do_configure() & do_configure_outside() functions to work with configure.gnu.
